### PR TITLE
Cacheable tipi deps

### DIFF
--- a/.tipi/deps
+++ b/.tipi/deps
@@ -6,5 +6,12 @@
     , "u" : true
 	  , "packages" : ["cryptopp"] 
     , "targets" : ["cryptopp-static"] 
-  } 
+  }
+  , "tipi-deps/boost" : {
+      "@" : "v1.80.0-without-submodules"
+    , "u" : true
+    , "packages" : ["boost_system", "boost_fusion"]
+    , "targets" : ["Boost::system", "Boost::fusion" ]
+  }
+
 }

--- a/.tipi/deps
+++ b/.tipi/deps
@@ -1,5 +1,4 @@
 {
-
   "cpp-pre/json" : { "@" : "feature/move-to-native-tipi-deps" }
   , "nxxm/xxhr" : { "@" : "feature/move-to-native-tipi-deps" }
   , "hunter-packages/cryptopp" : { "@" : "v8.2.0-p0" 
@@ -7,11 +6,11 @@
 	  , "packages" : ["cryptopp"] 
     , "targets" : ["cryptopp-static"] 
   }
-  , "tipi-deps/boost" : {
-      "@" : "v1.80.0-without-submodules"
-    , "u" : true
+  , "boostorg/boost" : { "@" : "boost-1.80.0",
+    "opts": "set(BOOST_INCLUDE_LIBRARIES system fusion)"
     , "packages" : ["boost_system", "boost_fusion"]
     , "targets" : ["Boost::system", "Boost::fusion" ]
-  }
+    , "u": true
+  } 
 
 }

--- a/.tipi/deps
+++ b/.tipi/deps
@@ -3,6 +3,7 @@
   , "nxxm/xxhr" : { "@" : "feature/move-to-native-tipi-deps" }
   , "hunter-packages/cryptopp" : { "@" : "v8.2.0-p0" 
     , "u" : true
+    , "opts" : "set (BUILD_SHARED OFF)"
 	  , "packages" : ["cryptopp"] 
     , "targets" : ["cryptopp-static"] 
   }

--- a/.tipi/deps
+++ b/.tipi/deps
@@ -1,6 +1,10 @@
 {
 
-	"cpp-pre/json" : { "@" : "feature/user-vault-cpp"},
-	"nxxm/xxhr" : {},
-	"platform": [{ "packages" : ["cryptopp"], "targets" : ["cryptopp-static"] }] 
+  "cpp-pre/json" : { "@" : "feature/move-to-native-tipi-deps" }
+  , "nxxm/xxhr" : { "@" : "feature/move-to-native-tipi-deps" }
+  , "hunter-packages/cryptopp" : { "@" : "v8.2.0-p0" 
+    , "u" : true
+	  , "packages" : ["cryptopp"] 
+    , "targets" : ["cryptopp-static"] 
+  } 
 }

--- a/.tipi/id
+++ b/.tipi/id
@@ -1,0 +1,1 @@
+{"host_name":"github.com","org_name":"tipi-build","repo_name":"vault"}

--- a/.tipi/opts.vs-16-2019-win64-cxx17
+++ b/.tipi/opts.vs-16-2019-win64-cxx17
@@ -1,0 +1,12 @@
+add_compile_definitions(
+    NOMINMAX
+    WIN32_LEAN_AND_MEAN
+    _WIN32_WINNT=0x0A00 # We have to set the windows version targeted
+    WINVER=0x0A00 # We have to set the windows version targeted
+    LYRA_CONFIG_OPTIONAL_TYPE=std::optional
+
+)
+
+add_compile_options(
+    /bigobj
+)


### PR DESCRIPTION
Changes to tipi deps file to build only with cacheable dependencies (no platform libs anymore)